### PR TITLE
Add gunicorn

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -7,7 +7,8 @@ ADD ./requirements/ /tmp/requirements/
 RUN apk --no-cache upgrade && \
 	apk --no-cache add git vim libffi libxml2 libxslt postgresql-client && \
 	apk --no-cache add \
-		postgresql-dev libffi-dev gcc musl-dev libxml2-dev libxslt-dev && \
+		postgresql-dev libffi-dev gcc g++ musl-dev libxml2-dev libxslt-dev libstdc++ && \
 	pip install --no-cache-dir --upgrade pip && \
 	pip install --no-cache-dir --upgrade --no-cache -r /tmp/requirements/$REQUIREMENTS.txt && \
-	apk del postgresql-dev libffi-dev gcc musl-dev libxml2-dev libxslt-dev
+	apk del postgresql-dev libffi-dev gcc g++ musl-dev libxml2-dev libxslt-dev libstdc++
+

--- a/python/requirements/django-2.0.txt
+++ b/python/requirements/django-2.0.txt
@@ -4,3 +4,6 @@ git+https://github.com/uisautomation/django-automationcommon/
 git+https://github.com/uisautomation/django-automationoauth/
 django-ucamlookup
 django-ucamwebauth
+gunicorn
+whitenoise
+brotlipy  # Support faster compression in whitenoise

--- a/python/requirements/django-2.1.txt
+++ b/python/requirements/django-2.1.txt
@@ -4,3 +4,6 @@ git+https://github.com/uisautomation/django-automationcommon/
 git+https://github.com/uisautomation/django-automationoauth/
 django-ucamlookup
 django-ucamwebauth
+gunicorn
+whitenoise
+brotlipy  # Support faster compression in whitenoise


### PR DESCRIPTION
gunicorn is our preferred web server in our django applications. Add it to the default docker image so it is already preinstalled when we import from it. Also throw into the mix whitenoise (for serving static files with gunicorn) and brotlipy (faster compression in whitenoise).