### PR TITLE
add common ansible-playbook packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,14 @@ jobs:
       - PYTHON_VERSION=3.7
       - REQUIREMENTS=django-2.1
 
+  ansible-2.6:
+    <<: *build_and_push
+    environment:
+      - IMAGE_TYPE=ansible-playbook
+      - IMAGE_NAME=ansible-playbook
+      - TAGS=2.6
+      - ANSIBLE_VERSION=2.6
+
 workflows:
   version: 2
 
@@ -96,6 +104,7 @@ workflows:
       - python-3.7-alpine
       - django-2.0-python-3.7-alpine
       - django-2.1-python-3.7-alpine
+      - ansible-2.6
 
   # The build_and_push flow but run nightly
   nightly:

--- a/ansible-playbook/Dockerfile
+++ b/ansible-playbook/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.7
+
+RUN pip install 'ansible~=$ANSIBLE_VERSION'
+
+ENV VAULT_PASSWORD=
+ADD ansible.cfg /etc/ansible/ansible.cfg
+ADD vault-password /usr/local/bin
+WORKDIR /workspace
+
+ENTRYPOINT ["ansible-playbook"]

--- a/ansible-playbook/README.md
+++ b/ansible-playbook/README.md
@@ -1,0 +1,16 @@
+# Ansible playbook
+
+Packaged Ansible playbook with vault support.
+
+Run via:
+
+```bash
+$ export VAULT_PASSWORD="some-password"
+$ docker run \
+    -t \
+    -e VAULT_PASSWORD \
+    -v ${SSH_AUTH_SOCK}:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent \
+    -v $PWD:/workspace:ro \
+    uisautomation/ansible-playbook:2.6 \
+    <ansible-playbook options>...
+```

--- a/ansible-playbook/ansible.cfg
+++ b/ansible-playbook/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+host_key_checking = False
+vault_password_file=/usr/local/bin/vault-password

--- a/ansible-playbook/vault-password
+++ b/ansible-playbook/vault-password
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ ! -z "${VAULT_PASSWORD}" ]; then
+  echo "Using vault password from VAULT_PASSWORD environment variable" >&2
+fi
+
+echo "${VAULT_PASSWORD}"


### PR DESCRIPTION
Add a common ansible-playbook image which can be used to run Ansible playbooks. The image teleports in SSH credentials from the host via ssh-agent and will use a vault password set in the environment variable "VAULT_PASSWORD".

See uisautomation/lecture-capture-backend-ansible#13 for an example of how this image can be used.