### PR TITLE
ansible: fix versioning specifier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
       - IMAGE_TYPE=ansible-playbook
       - IMAGE_NAME=ansible-playbook
       - TAGS=2.6
-      - ANSIBLE_VERSION=2.6
+      - ANSIBLE_VERSION=2.6.0
 
   ansible-2.7:
     <<: *build_and_push
@@ -98,7 +98,7 @@ jobs:
       - IMAGE_TYPE=ansible-playbook
       - IMAGE_NAME=ansible-playbook
       - TAGS=2.7
-      - ANSIBLE_VERSION=2.7
+      - ANSIBLE_VERSION=2.7.0
 
 workflows:
   version: 2


### PR DESCRIPTION
As noted in [1], the "compatible release" version semantics are a little unexpected in that "2.7" is considered compatible with "2.6". Using "2.6.0" and "2.7.0" should result in the expected behaviour.

[1] https://www.python.org/dev/peps/pep-0440/#compatible-release