### PR TITLE
add ucam-webauth-proxy image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,13 @@ jobs:
       - TAGS=2.7
       - ANSIBLE_VERSION=2.7.0
 
+  ucam-webauth-proxy:
+    <<: *build_and_push
+    environment:
+      - IMAGE_TYPE=ucam-webauth-proxy
+      - IMAGE_NAME=ucam-webauth-proxy
+      - TAGS=0.9 0.9.1 0.9-ucamwebauth-2.0.5 0.9-ucamwebauth-latest 0.9.1-ucamwebauth-2.0.5 0.9.1-ucamwebauth-latest ucamwebauth-2.0.5 ucamwebauth-latest latest
+
 workflows:
   version: 2
 
@@ -114,6 +121,7 @@ workflows:
       - django-2.1-python-3.7-alpine
       - ansible-2.6
       - ansible-2.7
+      - ucam-webauth-proxy
 
   # The build_and_push flow but run nightly
   nightly:

--- a/ucam-webauth-proxy/.editorconfig
+++ b/ucam-webauth-proxy/.editorconfig
@@ -1,0 +1,9 @@
+root=false
+
+[*.md]
+indent_style=space
+indent_size=2
+
+[*.sh]
+indent_style=space
+indent_size=2

--- a/ucam-webauth-proxy/Dockerfile
+++ b/ucam-webauth-proxy/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:xenial
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y vim wget apache2 libssl1.0.0 \
+    && wget https://s3.eu-west-2.amazonaws.com/uk.ac.cam.uis.mws/libapache2-mod-ucam-webauth_2.0.5apache24_ubuntu-16.04_amd64.deb \
+    && dpkg -i libapache2-mod-ucam-webauth_2.0.5apache24_ubuntu-16.04_amd64.deb \
+    && rm -f libapache2-mod-ucam-webauth_2.0.5apache24_ubuntu-16.04_amd64.deb \
+    && a2enmod proxy proxy_connect proxy_http rewrite ssl ucam_webauth authnz_ldap ldap \
+    && a2dissite 000-default \
+    && apt-get autoclean \
+    && mkdir -p /etc/apache2/conf/webauth_keys \
+    && cd /etc/apache2/conf/webauth_keys \
+    && wget https://raven.cam.ac.uk/project/keys/pubkey2 \
+    && ln -sf /proc/self/fd/1 /var/log/proxy-access.log \
+    && ln -sf /proc/self/fd/2 /var/log/proxy-error.log
+
+ADD entrypoint.sh /usr/local/bin
+ADD ./sites/ /etc/apache2/sites-enabled/
+
+ENV APACHE_RUN_USER www-data
+ENV APACHE_RUN_GROUP www-data
+ENV APACHE_LOG_DIR /var/log/apache2
+ENV APACHE_LOCK_DIR /var/lock/apache2
+ENV APACHE_PID_FILE /var/run/apache2.pid
+
+EXPOSE 80
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ucam-webauth-proxy/README.md
+++ b/ucam-webauth-proxy/README.md
@@ -1,0 +1,67 @@
+# Simple UcamWebAuth Proxy
+
+This container provides a basic Apache configuration which can be used to proxy
+another container and protect resources via UcamWebAuth. By default resources
+may be accessed by any valid UcamWebAuth user. Optionally resources may be
+further constrained by Lookup group.
+
+## Example
+
+```bash
+$ docker run --rm -it \
+    -e SERVER_NAME=localhost \
+    -e BACKEND_URL=http://www.example.com/ \
+    -p 8080:80 \
+    uisautomation/ucam-webauth-proxy
+```
+
+Visiting http://localhost:8080/ results in a UcamWebAuth-protected instance of
+http://example.com/.
+
+Access may be further restricted to a given Lookup group. For example, to
+restrict a resource to members of the [UIS
+group](https://www.lookup.cam.ac.uk/group/uis-members):
+
+```bash
+$ docker run --rm -it \
+    -e SERVER_NAME=localhost \
+    -e BACKEND_URL=http://www.example.com/ \
+    -e LOOKUP_GROUP_ID=101611 \
+    -p 8080:80 \
+    uisautomation/ucam-webauth-proxy
+```
+
+## Configuration
+
+The following environment variables are used for configuration:
+
+* BACKEND_URL (required) - URL of site to proxy. Example: http://example.com/
+* SERVER_NAME (required) - FQDN of site. Used by mod_ucam_webauth module to
+    ensure that the user is on the "canonical" site.
+* LOOKUP_GROUP_ID (optional) - Lookup group ID to further restrict valid users.
+
+## Replicated deployment
+
+For convenience, the container generates a random key used to encrypt the
+session cookie if one is not specified. For a replicated deployment, you will
+want to use the same cookie for each replica. It can be mounted inside the
+container via a volume:
+
+```bash
+# Generate the cookie
+$ head -c 64 /dev/urandom > webauthcookie.key
+
+# Launch the proxy
+$ docker run --rm -it \
+    -e SERVER_NAME=localhost \
+    -e BACKEND_URL=http://www.example.com/ \
+    -v $PWD/webauthcookie.key:/etc/apache2/webauthcookie.key:ro \
+    -p 8080:80 \
+    uisautomation/ucam-webauth-proxy
+```
+
+## Building the container
+
+The container is available on Docker hub but may be built explicitly via the
+usual ``docker build -t uisautomation/ucam-webauth-proxy .`` command issued in
+the root of the repository.

--- a/ucam-webauth-proxy/entrypoint.sh
+++ b/ucam-webauth-proxy/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+
+umask 0077
+
+cookie_key_file="/etc/apache2/webauthcookie.key"
+if [ ! -f "${cookie_key_file}" ]; then
+  echo "-- Generating new webauth cookie key."
+  head -c 64 /dev/urandom > "${cookie_key_file}"
+else
+  echo "-- Using existing webauth cookie key."
+fi
+
+extra_args=""
+
+if [ -z "${SERVER_NAME}" ]; then
+  echo "!! SERVER_NAME must be set to the FQDN for the server." >&2
+  exit 1
+fi
+
+if [ -z "${BACKEND_URL}" ]; then
+  echo "!! BACKEND_URL must be set to the base URL to proxy." >&2
+  exit 1
+fi
+
+if [ ! -z "${LOOKUP_GROUP_ID}" ]; then
+  echo "Adding extra restriction: lookup group id=${LOOKUP_GROUP_ID}."
+  extra_args="${extra_args} -D WithLDAPGroup"
+fi
+
+echo "-- Starting apache"
+exec /usr/sbin/apachectl -D FOREGROUND ${extra_args}

--- a/ucam-webauth-proxy/sites/proxy.conf
+++ b/ucam-webauth-proxy/sites/proxy.conf
@@ -1,0 +1,34 @@
+ServerName ${SERVER_NAME}
+LDAPTrustedMode TLS
+
+<VirtualHost *:80>
+    DocumentRoot /var/www/html
+
+    ErrorLog /var/log/proxy-error.log
+    CustomLog /var/log/proxy-access.log combined
+
+    AACookieKey "file:/etc/apache2/webauthcookie.key"
+
+    # Container should usually have a pretty good time source but be generous to
+    # allow for poorly synchronised clocks.
+    AAClockSkew 2
+
+    <Location />
+        ProxyPass "${BACKEND_URL}"
+        ProxyPassReverse "${BACKEND_URL}"
+
+        AuthType Ucam-WebAuth
+
+        <RequireAll>
+            Require valid-user
+
+            # https://wiki.cam.ac.uk/raven/Mod_authnz_ldap#Allow_access_only_member_of_group_on_a_list
+            <IfDefine WithLDAPGroup>
+                AuthLDAPUrl ldap://ldap.lookup.cam.ac.uk/ou=people,o=University%20of%20Cambridge,dc=cam,dc=ac,dc=uk
+                Require ldap-attribute groupID=${LOOKUP_GROUP_ID}
+            </IfDefine>
+        </RequireAll>
+    </Location>
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr et


### PR DESCRIPTION
Add a simple proxy which can restrict access to a resource to anyone with a Raven account or to those within a specific lookup group. This is based on https://github.com/rjw57/ucam-webauth-proxy which is currently being used to protect our Traefik dashboard.

I've set the version number of the build to 0.9 since we've not hammered on it much yet and I'd like the freedom to innovate before a 1.0. That being said, it's deployed already and works so we could bump to 1.0 once we're happy.